### PR TITLE
Acceptance test framework usability and failing test performance fix

### DIFF
--- a/final/ticket-service-acceptance-tests/src/test/java/com/training/epam/ticketservice/at/GenericCliProcessStepDefs.java
+++ b/final/ticket-service-acceptance-tests/src/test/java/com/training/epam/ticketservice/at/GenericCliProcessStepDefs.java
@@ -8,12 +8,15 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import java.io.IOException;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public class GenericCliProcessStepDefs {
 
     private static final int OUTPUT_TIMEOUT = 30000;
+    private static final String jarFile = "../ticket-service/target/ticket-service-0.0.1-SNAPSHOT.jar";
 
     private ProcessUnderTest cliProcess;
 
@@ -23,6 +26,9 @@ public class GenericCliProcessStepDefs {
 
     @Given("the application is started")
     public void applicationStarted() throws IOException, InterruptedException {
+        if (!(new File(jarFile)).isFile()){
+            throw new FileNotFoundException("The path " + jarFile + " does not exist. It should be your built JAR file.");
+        }
         cliProcess.run("java -jar -Dspring.profiles.active=ci ../ticket-service/target/ticket-service-0.0.1-SNAPSHOT.jar");
     }
 

--- a/final/ticket-service-acceptance-tests/src/test/java/com/training/epam/ticketservice/at/ProcessUnderTest.java
+++ b/final/ticket-service-acceptance-tests/src/test/java/com/training/epam/ticketservice/at/ProcessUnderTest.java
@@ -68,7 +68,11 @@ public class ProcessUnderTest implements AutoCloseable {
     private Void readOutputUntil(String expectedOutput) throws IOException {
         String actualString = "";
         do {
-            actualString += (char) output.read();
+            int c = output.read();
+            if (c == -1) {
+                throw new IOException("Reached EOF before receiving '" + expectedOutput + "'");
+            }
+            actualString += (char) c;
             if (actualString.length() > expectedOutput.length()) {
                 actualString = actualString.substring(1);
             }


### PR DESCRIPTION
Fixes:
- the acceptance testing framework isn't helpful when the JAR isn't built yet
  - instead: give a more meaningful message
- if the test case EOFs for some reason, the test will keep going with high CPU usage until it hits the timeout
  - instead: actually check the return value of read() and throw an exception